### PR TITLE
Do not apply scopes on fields that don’t match our patterns

### DIFF
--- a/lib/microscope/scope/datetime_scope.rb
+++ b/lib/microscope/scope/datetime_scope.rb
@@ -10,6 +10,7 @@ module Microscope
       end
 
       def apply
+        return unless field.name =~ @cropped_field_regex
         @cropped_field = field.name.gsub(@cropped_field_regex, '')
 
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1

--- a/spec/microscope/scope/date_scope_spec.rb
+++ b/spec/microscope/scope/date_scope_spec.rb
@@ -7,6 +7,7 @@ describe Microscope::Scope::DateScope do
     run_migration do
       create_table(:events, force: true) do |t|
         t.date :started_on, default: nil
+        t.date :published_date, default: nil
       end
     end
 
@@ -91,5 +92,12 @@ describe Microscope::Scope::DateScope do
       subject { Event.create(started_on: 2.months.from_now) }
       it { should_not be_started }
     end
+  end
+
+  context 'for field that does not match the pattern' do
+    subject { Event }
+
+    it { should_not respond_to(:published_date) }
+    it { should_not respond_to(:not_published_date) }
   end
 end

--- a/spec/microscope/scope/datetime_scope_spec.rb
+++ b/spec/microscope/scope/datetime_scope_spec.rb
@@ -5,6 +5,7 @@ describe Microscope::Scope::DatetimeScope do
     run_migration do
       create_table(:events, force: true) do |t|
         t.datetime :started_at, default: nil
+        t.datetime :published_date, default: nil
       end
     end
 
@@ -89,5 +90,12 @@ describe Microscope::Scope::DatetimeScope do
       subject { Event.create(started_at: 2.months.from_now) }
       it { should_not be_started }
     end
+  end
+
+  context 'for field that does not match the pattern' do
+    subject { Event }
+
+    it { should_not respond_to(:published_date) }
+    it { should_not respond_to(:not_published_date) }
   end
 end


### PR DESCRIPTION
We want to make sure that we only add scopes for datetime fields that match `/_at$/` and date fields that match `/_on$/`.
