### PR TITLE
Add <field>! method to instances

### DIFF
--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -9,6 +9,7 @@ require "microscope/scope/datetime_scope"
 require "microscope/scope/date_scope"
 
 require "microscope/instance_method"
+require "microscope/instance_method/boolean_instance_method"
 require "microscope/instance_method/datetime_instance_method"
 require "microscope/instance_method/date_instance_method"
 

--- a/lib/microscope/instance_method.rb
+++ b/lib/microscope/instance_method.rb
@@ -10,5 +10,14 @@ module Microscope
         end
       end
     end
+
+    # Convert a past participle to its infinitive form
+    def self.past_participle_to_infinitive(participle)
+      if participle =~ /ed$/
+        participle.sub(/ed$/, '')
+      else
+        participle
+      end
+    end
   end
 end

--- a/lib/microscope/instance_method/boolean_instance_method.rb
+++ b/lib/microscope/instance_method/boolean_instance_method.rb
@@ -1,0 +1,16 @@
+module Microscope
+  class InstanceMethod
+    class BooleanInstanceMethod < InstanceMethod
+      def apply
+        infinitive_verb = self.class.past_participle_to_infinitive(field.name)
+
+        model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          define_method "#{infinitive_verb}!" do
+            send("#{field.name}=", true)
+            save!
+          end
+        RUBY
+      end
+    end
+  end
+end

--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -3,6 +3,7 @@ module Microscope
     class DateInstanceMethod < InstanceMethod
       def apply
         cropped_field = field.name.gsub(/_on$/, '')
+        infinitive_verb = self.class.past_participle_to_infinitive(cropped_field)
 
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           define_method "#{cropped_field}?" do
@@ -12,6 +13,11 @@ module Microscope
 
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
+          end
+
+          define_method "#{infinitive_verb}!" do
+            send("#{field.name}=", Date.today)
+            save!
           end
         RUBY
       end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -3,6 +3,7 @@ module Microscope
     class DatetimeInstanceMethod < InstanceMethod
       def apply
         cropped_field = field.name.gsub(/_at$/, '')
+        infinitive_verb = self.class.past_participle_to_infinitive(cropped_field)
 
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           define_method "#{cropped_field}?" do
@@ -12,6 +13,11 @@ module Microscope
 
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
+          end
+
+          define_method "#{infinitive_verb}!" do
+            send("#{field.name}=", Time.now)
+            save!
           end
         RUBY
       end

--- a/spec/microscope/instance_method/boolean_instance_method_spec.rb
+++ b/spec/microscope/instance_method/boolean_instance_method_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Microscope::InstanceMethod::BooleanInstanceMethod do
+  before do
+    run_migration do
+      create_table(:events, force: true) do |t|
+        t.boolean :started, default: false
+      end
+    end
+
+    microscope 'Event'
+  end
+
+  describe '#start!' do
+    let(:event) { Event.create(started: false) }
+    it { expect { event.start! }.to change { event.reload.started }.from(false).to(true) }
+  end
+end

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -36,4 +36,12 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
       it { should be_not_started }
     end
   end
+
+  describe '#start!' do
+    let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
+    before { Date.stub(:today).and_return(stubbed_date) }
+
+    let(:event) { Event.create(started_on: nil) }
+    it { expect { event.start! }.to change { event.reload.started_on }.from(nil).to(stubbed_date) }
+  end
 end

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -34,4 +34,12 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
       it { should be_not_started }
     end
   end
+
+  describe '#start!' do
+    let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
+    before { Time.stub(:now).and_return(stubbed_date) }
+
+    let(:event) { Event.create(started_at: nil) }
+    it { expect { event.start! }.to change { event.reload.started_at }.from(nil).to(stubbed_date) }
+  end
 end


### PR DESCRIPTION
Calling `start!` on a record that has a `started_on` or `started_at` attribute will set the attribute to now (`Date.today` or `Time.now`). If the record has a boolean `started` field, it will be set to true.

The `past_participle_to_infinitive` method is very basic, but I’m planning to improve it in another pull request to deal with irregular verbs (like `send`).
