### PR TITLE
Fix regular verbs conversion

### DIFF
--- a/data/irregular_verbs.yml
+++ b/data/irregular_verbs.yml
@@ -121,6 +121,7 @@ spat: spit
 split: split
 spread: spread
 sprung: spring
+started: start
 stood: stand
 stolen: steal
 stuck: stick

--- a/lib/microscope/instance_method.rb
+++ b/lib/microscope/instance_method.rb
@@ -16,7 +16,7 @@ module Microscope
       if Microscope.irregular_verbs.include?(participle)
         Microscope.irregular_verbs[participle]
       elsif participle =~ /ed$/
-        participle.sub(/ed$/, '')
+        participle.sub(/d$/, '')
       else
         participle
       end

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -5,6 +5,7 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
     run_migration do
       create_table(:events, force: true) do |t|
         t.datetime :started_at, default: nil
+        t.datetime :featured_at, default: nil
       end
     end
 
@@ -41,5 +42,7 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
 
     let(:event) { Event.create(started_at: nil) }
     it { expect { event.start! }.to change { event.reload.started_at }.from(nil).to(stubbed_date) }
+    it { expect(event).to respond_to(:start!) }
+    it { expect(event).to respond_to(:feature!) }
   end
 end


### PR DESCRIPTION
`featured` → `feature`
`liked` → `like`
`loved` → `love`
`started` → `start`

Looks like `started` is the exception here.
