### PR TITLE
Add setter method for datetime and date attributes

### DIFF
--- a/lib/microscope/instance_method.rb
+++ b/lib/microscope/instance_method.rb
@@ -21,5 +21,10 @@ module Microscope
         participle
       end
     end
+
+    # Convert a value to its boolean representation
+    def self.value_to_boolean(value)
+      ![nil, false, 0, '0', 'f', 'F', 'false', 'FALSE'].include?(value.presence)
+    end
   end
 end

--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -11,6 +11,14 @@ module Microscope
             !value.nil? && value <= Date.today
           end
 
+          define_method "#{cropped_field}=" do |value|
+            if Microscope::InstanceMethod.value_to_boolean(value)
+              self.#{field.name} = Date.today
+            else
+              self.#{field.name} = nil
+            end
+          end
+
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
           end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -11,6 +11,14 @@ module Microscope
             !value.nil? && value <= Time.now
           end
 
+          define_method "#{cropped_field}=" do |value|
+            if Microscope::InstanceMethod.value_to_boolean(value)
+              self.#{field.name} = Time.now
+            else
+              self.#{field.name} = nil
+            end
+          end
+
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
           end

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -25,6 +25,24 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
     end
   end
 
+  describe '#started=' do
+    before { subject.started = value }
+
+    context 'with present argument' do
+      subject { Event.create(started_on: 2.months.ago) }
+      let(:value) { '0' }
+
+      it { should_not be_started }
+    end
+
+    context 'with blank argument' do
+      subject { Event.create }
+      let(:value) { '1' }
+
+      it { should be_started }
+    end
+  end
+
   describe '#not_started?' do
     context 'with negative result' do
       subject { Event.create(started_on: 2.months.ago) }

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -23,6 +23,24 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
     end
   end
 
+  describe '#started=' do
+    before { subject.started = value }
+
+    context 'with present argument' do
+      subject { Event.create(started_at: 2.months.ago) }
+      let(:value) { '0' }
+
+      it { should_not be_started }
+    end
+
+    context 'with blank argument' do
+      subject { Event.create }
+      let(:value) { '1' }
+
+      it { should be_started }
+    end
+  end
+
   describe '#not_started?' do
     context 'with negative result' do
       subject { Event.create(started_at: 2.months.ago) }


### PR DESCRIPTION
To use Rails form builders in combination with our “_fake_” boolean attributes, we have to define setter attributes.
