### PR TITLE
Fix multiple setter calls bug

### DIFF
--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -13,7 +13,7 @@ module Microscope
 
           define_method "#{cropped_field}=" do |value|
             if Microscope::InstanceMethod.value_to_boolean(value)
-              self.#{field.name} = Date.today
+              self.#{field.name} ||= Date.today
             else
               self.#{field.name} = nil
             end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -13,7 +13,7 @@ module Microscope
 
           define_method "#{cropped_field}=" do |value|
             if Microscope::InstanceMethod.value_to_boolean(value)
-              self.#{field.name} = Time.now
+              self.#{field.name} ||= Time.now
             else
               self.#{field.name} = nil
             end

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -28,18 +28,28 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
   describe '#started=' do
     before { subject.started = value }
 
-    context 'with present argument' do
+    context 'with blank argument' do
       subject { Event.create(started_on: 2.months.ago) }
       let(:value) { '0' }
 
       it { should_not be_started }
     end
 
-    context 'with blank argument' do
+    context 'with present argument' do
       subject { Event.create }
       let(:value) { '1' }
 
       it { should be_started }
+    end
+
+    context 'with present argument, twice' do
+      subject { Event.create(started_on: time) }
+      let(:time) { 2.months.ago }
+      let(:value) { '1' }
+
+      it { expect(subject.started_on.day).to eql time.day }
+      it { expect(subject.started_on.month).to eql time.month }
+      it { expect(subject.started_on.year).to eql time.year }
     end
   end
 

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -26,18 +26,26 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
   describe '#started=' do
     before { subject.started = value }
 
-    context 'with present argument' do
+    context 'with blank argument' do
       subject { Event.create(started_at: 2.months.ago) }
       let(:value) { '0' }
 
       it { should_not be_started }
     end
 
-    context 'with blank argument' do
+    context 'with present argument' do
       subject { Event.create }
       let(:value) { '1' }
 
       it { should be_started }
+    end
+
+    context 'with present argument, twice' do
+      subject { Event.create(started_at: time) }
+      let(:time) { 2.months.ago }
+      let(:value) { '1' }
+
+      it { expect(subject.started_at).to eql time }
     end
   end
 


### PR DESCRIPTION
Before this pull request:

``` ruby
@event.started_at # => nil

@event.started = true
@event.started_at # => 2014-01-15 15:13:00

@event.started = true
@event.started_at # => 2014-01-15 15:13:01

@event.started = true
@event.started_at # => 2014-01-15 15:13:02
```

After this pull request:

``` ruby
@event.started_at # => nil

@event.started = true
@event.started_at # => 2014-01-15 15:13:00

@event.started = true
@event.started_at # => 2014-01-15 15:13:00

@event.started = true
@event.started_at # => 2014-01-15 15:13:00
```
