### PR TITLE
Add negative bang instance methods

### DIFF
--- a/lib/microscope/instance_method/boolean_instance_method.rb
+++ b/lib/microscope/instance_method/boolean_instance_method.rb
@@ -14,7 +14,7 @@ module Microscope
             send("#{field.name}=", false)
             save!
           end
-          alias_method 'un_#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+          alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
         RUBY
       end
     end

--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -41,7 +41,7 @@ module Microscope
             send("#{field.name}=", nil)
             save!
           end
-          alias_method 'un_#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+          alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
         RUBY
       end
     end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -41,7 +41,7 @@ module Microscope
             send("#{field.name}=", nil)
             save!
           end
-          alias_method 'un_#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+          alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
         RUBY
       end
     end

--- a/spec/microscope/instance_method/boolean_instance_method_spec.rb
+++ b/spec/microscope/instance_method/boolean_instance_method_spec.rb
@@ -19,6 +19,6 @@ describe Microscope::InstanceMethod::BooleanInstanceMethod do
   describe '#not_feed!' do
     let(:animal) { Animal.create(fed: true) }
     it { expect { animal.not_feed! }.to change { animal.reload.fed? }.from(true).to(false) }
-    it { expect(animal).to respond_to(:un_feed!) }
+    it { expect(animal).to respond_to(:unfeed!) }
   end
 end

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -85,6 +85,6 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
 
     let(:event) { Event.create(started_on: stubbed_date) }
     it { expect { event.not_start! }.to change { event.reload.started_on }.from(stubbed_date).to(nil) }
-    it { expect(event).to respond_to(:un_start!) }
+    it { expect(event).to respond_to(:unstart!) }
   end
 end

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -74,6 +74,6 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
 
     let(:event) { Event.create(started_at: stubbed_date) }
     it { expect { event.not_start! }.to change { event.reload.started_at }.from(stubbed_date).to(nil) }
-    it { expect(event).to respond_to(:un_start!) }
+    it { expect(event).to respond_to(:unstart!) }
   end
 end


### PR DESCRIPTION
I added a reverse _bang_ method. So for example, if we have an `archived_at` column, we would have both `archive!` and `unarchive!` (alias from `not_archive!`) methods to toggle a record archive state.

![](http://25.media.tumblr.com/bf5384db70aeee86684236ca51f0a7cc/tumblr_mibdb7Z2q81r0ujc2o1_500.gif)
