### PR TITLE
Add `.un<field>` boolean scope

### DIFF
--- a/lib/microscope/scope/boolean_scope.rb
+++ b/lib/microscope/scope/boolean_scope.rb
@@ -5,6 +5,7 @@ module Microscope
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           scope "#{@field_name}", lambda { where("#{@field_name}" => true) }
           scope "not_#{@field_name}", lambda { where("#{@field_name}" => false) }
+          scope "un#{@field_name}", lambda { not_#{@field_name} }
         RUBY
       end
     end

--- a/lib/microscope/scope/datetime_scope.rb
+++ b/lib/microscope/scope/datetime_scope.rb
@@ -48,6 +48,7 @@ module Microscope
         <<-RUBY
           scope "#{cropped_field}", lambda { where('#{quoted_field} IS NOT NULL AND #{quoted_field} <= ?', #{@now}) }
           scope "not_#{cropped_field}", lambda { where('#{quoted_field} IS NULL OR #{quoted_field} > ?', #{@now}) }
+          scope "un#{cropped_field}", lambda { not_#{cropped_field} }
         RUBY
       end
     end

--- a/spec/microscope/scope/boolean_scope_spec.rb
+++ b/spec/microscope/scope/boolean_scope_spec.rb
@@ -29,5 +29,6 @@ describe Microscope::Scope::BooleanScope do
 
     it { expect(User.not_active).to have(1).items }
     it { expect(User.not_active).to include(@user1) }
+    it { expect(User.unactive.to_a).to eql User.not_active.to_a }
   end
 end

--- a/spec/microscope/scope/date_scope_spec.rb
+++ b/spec/microscope/scope/date_scope_spec.rb
@@ -78,6 +78,7 @@ describe Microscope::Scope::DateScope do
     end
 
     it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
+    it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
   end
 
   describe 'boolean instance method' do

--- a/spec/microscope/scope/datetime_scope_spec.rb
+++ b/spec/microscope/scope/datetime_scope_spec.rb
@@ -78,6 +78,7 @@ describe Microscope::Scope::DatetimeScope do
     end
 
     it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
+    it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
   end
 
   describe 'boolean instance method' do


### PR DESCRIPTION
We already have `#un<field>!` and `#not_<field>!` instance methods but only a `.not_<field>` scope.

This pull request adds a `.un<field>` scope so now `Message.unread` is the same as `Message.not_read`.
