### PR TITLE
Add unverb? as an alias for not_verb?

### DIFF
--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -31,6 +31,7 @@ module Microscope
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
           end
+          alias_method 'un#{cropped_field}?', 'not_#{cropped_field}?'
 
           define_method "#{infinitive_verb}!" do
             send("#{field.name}=", #{@now})

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -31,6 +31,7 @@ module Microscope
           define_method "not_#{cropped_field}?" do
             !#{cropped_field}?
           end
+          alias_method 'un#{cropped_field}?', 'not_#{cropped_field}?'
 
           define_method "#{infinitive_verb}!" do
             send("#{field.name}=", #{@now})

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -64,6 +64,7 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
     context 'with negative result' do
       let(:event) { Event.create(started_on: 2.months.ago) }
       it { expect(event).to_not be_not_started }
+      it { expect(event).to respond_to(:unstarted?) }
     end
 
     context 'with positive result' do

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -53,6 +53,7 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
     context 'with negative result' do
       let(:event) { Event.create(started_at: 2.months.ago) }
       it { expect(event).to_not be_not_started }
+      it { expect(event).to respond_to(:unstarted?) }
     end
 
     context 'with positive result' do


### PR DESCRIPTION
We can, in the 0.5.8 version use the `unread` scope but not the `unread?` instance method.
