### PR TITLE
Add Microscope.configure to configure special verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ create_table "events" do |t|
   t.string   "name"
   t.boolean  "special"
   t.datetime "expired_at"
-  t.date     "started_on"
+  t.date     "archived_on"
 end
 
 class Event < ActiveRecord::Base
@@ -57,39 +57,59 @@ Event.expired_after_or_at(2.months.from_now)
 Event.expired_between(2.months.ago..1.month.from_now)
 # SELECT * FROM `events` where `events`.`expired_at` BETWEEN '2013-05-05 15:43:42' AND '2013-08-05 15:43:42'
 
-Event.started_before(2.days.ago)
-# SELECT * FROM `events` where `events`.`started_on` < '2013-07-03'
+Event.archived_before(2.days.ago)
+# SELECT * FROM `events` where `events`.`archived_on` < '2013-07-03'
 
-Event.started_between(2.days.ago..3.days.from_now)
-# SELECT * FROM `events` where `events`.`started_on` BETWEEN '2013-07-03' AND '2013-07-08'
+Event.archived_between(2.days.ago..3.days.from_now)
+# SELECT * FROM `events` where `events`.`archived_on` BETWEEN '2013-07-03' AND '2013-07-08'
 
-Event.started
-# SELECT * FROM `events` where `events`.`started_at` IS NOT NULL AND `events`.`started_at` <= '2013-07-05 15:43:42'
+Event.archived
+# SELECT * FROM `events` where `events`.`archived_on` IS NOT NULL AND `events`.`archived_on` <= '2013-07-05 15:43:42'
 
-Event.not_started
-# SELECT * FROM `events` where `events`.`started_at` IS NULL OR `events`.`started_at` > '2013-07-05 15:43:42'
+Event.not_archived
+# SELECT * FROM `events` where `events`.`archived_on` IS NULL OR `events`.`archived_on` > '2013-07-05 15:43:42'
 ```
 
 Microscope also adds three instance methods to the model per scope.
 
 ```ruby
-event = Event.started.first
-# SELECT * FROM `events` where `events`.`started_at` IS NOT NULL AND `events`.`started_at` <= '2013-07-05 15:43:42' LIMIT 1
+event = Event.archived.first
+# SELECT * FROM `events` where `events`.`archived_on` IS NOT NULL AND `events`.`archived_on` <= '2013-07-05 15:43:42' LIMIT 1
 
-event.started? # => true
-event.not_started? # => false
+event.archived? # => true
+event.not_archived? # => false
 
-event = Event.unstarted.first
-event.started? # => false
+event = Event.unarchived.first
+event.archived? # => false
 
-event.start!
-event.started? # => true
-event.started_at # => 2013-07-05 15:43:44 (Time.now)
+event.archive!
+event.archived? # => true
+event.archived_at # => 2013-07-05 15:43:44 (Time.now)
 ```
 
 ### Options
 
-You can use a few options when calling `acts_as_microscope`:
+#### Special verbs
+
+Microscope uses a rather simple process to convert field names to infinitive
+verbs. It just removes the `d` if there’s one at the end of the verb. It also
+has its own irregular verbs list.
+
+For example, a `liked_at` field name will give `like!` and `unlike!` instance
+methods to records.
+
+But you can configure Microscope to use your own special verbs. For example:
+
+```ruby
+# config/initializers/microscope.rb
+Microscope.configure do |config|
+  config.special_verbs = { 'extracted' => 'extract', 'started' => 'start' }
+end
+```
+
+#### On `acts_as_microscope`
+
+You can also use a few options when calling `acts_as_microscope`:
 
 ```ruby
 class Event < ActiveRecord::Base

--- a/data/irregular_verbs.yml
+++ b/data/irregular_verbs.yml
@@ -18,7 +18,6 @@ burnt: burn
 burst: burst
 bought: buy
 caught: catch
-canceled: cancel
 cancelled: cancel
 chosen: choose
 clung: cling
@@ -32,17 +31,14 @@ dived: dive
 done: do
 drawn: draw
 dreamt: dream
-dreamed: dream
 drunk: drink
 driven: drive
 eaten: eat
-extracted: extract
 fallen: fall
 fed: feed
 felt: feel
 fought: fight
 found: find
-filtered: filter
 fit: fit
 fled: flee
 flung: fling
@@ -125,7 +121,6 @@ spat: spit
 split: split
 spread: spread
 sprung: spring
-started: start
 stood: stand
 stolen: steal
 stuck: stick

--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -1,5 +1,6 @@
 require "microscope/version"
 
+require 'ostruct'
 require 'active_record'
 require 'active_support'
 
@@ -16,8 +17,22 @@ require "microscope/instance_method/date_instance_method"
 module Microscope
   IRREGULAR_VERBS_FILE = File.expand_path('../../data/irregular_verbs.yml', __FILE__)
 
-  def self.irregular_verbs
-    @irregular_verbs ||= YAML.load_file(IRREGULAR_VERBS_FILE)
+  def self.special_verbs
+    irregular_verbs_from_yaml ||= YAML.load_file(IRREGULAR_VERBS_FILE)
+    special_verbs_from_configuration ||= configuration.special_verbs
+
+    @special_verbs ||= begin
+      irregular_verbs_from_yaml.merge(special_verbs_from_configuration)
+    end
+  end
+
+  def self.configure
+    @configuration = configuration
+    yield(@configuration)
+  end
+
+  def self.configuration
+    @configuration ||= OpenStruct.new(special_verbs: {})
   end
 end
 

--- a/lib/microscope/instance_method.rb
+++ b/lib/microscope/instance_method.rb
@@ -24,8 +24,8 @@ module Microscope
     def self.past_participle_to_infinitive(key)
       *key, participle = key.split('_')
 
-      infinitive = if Microscope.irregular_verbs.include?(participle)
-        Microscope.irregular_verbs[participle]
+      infinitive = if Microscope.special_verbs.include?(participle)
+        Microscope.special_verbs[participle]
       elsif participle =~ /ed$/
         participle.sub(/d$/, '')
       else

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe Microscope::InstanceMethod::DateInstanceMethod do
   before do
+    Microscope.configure do |config|
+      config.special_verbs = { 'started' => 'start' }
+    end
+
     run_migration do
       create_table(:events, force: true) do |t|
         t.date :start_date, default: nil

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe Microscope::InstanceMethod::DatetimeInstanceMethod do
   before do
+    Microscope.configure do |config|
+      config.special_verbs = { 'started' => 'start' }
+    end
+
     run_migration do
       create_table(:events, force: true) do |t|
         t.datetime :started_at, default: nil

--- a/spec/microscope/instance_method_spec.rb
+++ b/spec/microscope/instance_method_spec.rb
@@ -3,8 +3,14 @@ require 'spec_helper'
 describe Microscope::InstanceMethod do
   describe :ClassMethods do
     describe :past_participle_to_infinitive do
-      let(:past_participles) { ['liked', 'loved', 'gateway_canceled', 'started', 'fed'] }
-      let(:infinitives) { ['like', 'love', 'gateway_cancel', 'start', 'feed'] }
+      before do
+        Microscope.configure do |config|
+          config.special_verbs = { 'started' => 'start', 'foo' => 'bar', 'canceled' => 'cancel' }
+        end
+      end
+
+      let(:past_participles) { ['liked', 'loved', 'gateway_canceled', 'started', 'fed', 'foo'] }
+      let(:infinitives) { ['like', 'love', 'gateway_cancel', 'start', 'feed', 'bar'] }
       let(:mapped_past_participles) { past_participles.map { |v| Microscope::InstanceMethod.past_participle_to_infinitive(v) } }
 
       specify do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,12 @@ RSpec.configure do |config|
   config.include ModelMacros
 
   config.before :each do
+    # Establish ActiveRecord database connection
     adapter = ENV['DB_ADAPTER'] || 'sqlite3'
     setup_database(adapter: adapter, database: 'microscope_test')
+
+    # Reset internal variables
+    Microscope.instance_variable_set(:@configuration, nil)
+    Microscope.instance_variable_set(:@special_verbs, nil)
   end
 end


### PR DESCRIPTION
_Extract from README.md_:

> Microscope uses a rather simple process to convert field names to infinitive verbs. It just removes the `d` if there’s one at the end of the verb. It also has its own irregular verbs list.
> 
> For example, a `liked_at` field name will give `like!` and `unlike!` instance methods to records.
> 
> But you can configure Microscope to use your own special verbs. For example:
> 
> ```
> # config/initializers/microscope.rb
> Microscope.configure do |config|
>   config.special_verbs = { 'extracted' => 'extract', 'started' => 'start' }
> end
> ```

I also made sure the first examples in `README.md` were not using any irregular verbs, as they wouldn’t not be _runnable_ without a special `irregular_verbs` configuration.
