### PR TITLE
Add #mark_as_<verb> and #mark_as_not_<verb> instance methods

### DIFF
--- a/lib/microscope/instance_method/boolean_instance_method.rb
+++ b/lib/microscope/instance_method/boolean_instance_method.rb
@@ -15,6 +15,15 @@ module Microscope
             save!
           end
           alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+
+          define_method "mark_as_#{field.name}" do
+            send("#{field.name}=", true)
+          end
+
+          define_method "mark_as_not_#{field.name}" do
+            send("#{field.name}=", false)
+          end
+          alias_method 'mark_as_un#{field.name}', 'mark_as_not_#{field.name}'
         RUBY
       end
     end

--- a/lib/microscope/instance_method/date_instance_method.rb
+++ b/lib/microscope/instance_method/date_instance_method.rb
@@ -1,49 +1,11 @@
 module Microscope
   class InstanceMethod
-    class DateInstanceMethod < InstanceMethod
+    class DateInstanceMethod < DatetimeInstanceMethod
       def initialize(*args)
         super
 
         @now = 'Date.today'
         @cropped_field_regex = /_on$/
-      end
-
-      def apply
-        return unless @field_name =~ @cropped_field_regex
-
-        cropped_field = field.name.gsub(@cropped_field_regex, '')
-        infinitive_verb = self.class.past_participle_to_infinitive(cropped_field)
-
-        model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          define_method "#{cropped_field}?" do
-            value = send("#{field.name}")
-            !value.nil? && value <= #{@now}
-          end
-
-          define_method "#{cropped_field}=" do |value|
-            if Microscope::InstanceMethod.value_to_boolean(value)
-              self.#{field.name} ||= #{@now}
-            else
-              self.#{field.name} = nil
-            end
-          end
-
-          define_method "not_#{cropped_field}?" do
-            !#{cropped_field}?
-          end
-          alias_method 'un#{cropped_field}?', 'not_#{cropped_field}?'
-
-          define_method "#{infinitive_verb}!" do
-            send("#{field.name}=", #{@now})
-            save!
-          end
-
-          define_method "not_#{infinitive_verb}!" do
-            send("#{field.name}=", nil)
-            save!
-          end
-          alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
-        RUBY
       end
     end
   end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -43,6 +43,15 @@ module Microscope
             save!
           end
           alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+
+          define_method "mark_as_#{cropped_field}" do
+            self.#{cropped_field}= true
+          end
+
+          define_method "mark_as_not_#{cropped_field}" do
+            self.#{cropped_field}= false
+          end
+          alias_method 'mark_as_un#{cropped_field}', 'mark_as_not_#{cropped_field}'
         RUBY
       end
     end

--- a/spec/microscope/instance_method/boolean_instance_method_spec.rb
+++ b/spec/microscope/instance_method/boolean_instance_method_spec.rb
@@ -21,4 +21,17 @@ describe Microscope::InstanceMethod::BooleanInstanceMethod do
     it { expect { animal.not_feed! }.to change { animal.reload.fed? }.from(true).to(false) }
     it { expect(animal).to respond_to(:unfeed!) }
   end
+
+  describe '#mark_as_fed' do
+    let(:animal) { Animal.create(fed: false) }
+    it { expect { animal.mark_as_fed }.to_not change { animal.reload.fed? } }
+    it { expect { animal.mark_as_fed }.to change { animal.fed? }.from(false).to(true) }
+  end
+
+  describe '#mark_as_not_fed' do
+    let(:animal) { Animal.create(fed: true) }
+    it { expect { animal.mark_as_not_fed }.to_not change { animal.reload.fed? } }
+    it { expect { animal.mark_as_not_fed }.to change { animal.fed? }.from(true).to(false) }
+    it { expect(animal).to respond_to(:mark_as_unfed) }
+  end
 end

--- a/spec/microscope/instance_method/date_instance_method_spec.rb
+++ b/spec/microscope/instance_method/date_instance_method_spec.rb
@@ -92,4 +92,22 @@ describe Microscope::InstanceMethod::DateInstanceMethod do
     it { expect { event.not_start! }.to change { event.reload.started_on }.from(stubbed_date).to(nil) }
     it { expect(event).to respond_to(:unstart!) }
   end
+
+  describe '#mark_as_started' do
+    let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
+    before { Date.stub(:today).and_return(stubbed_date) }
+
+    let(:event) { Event.create(started_on: nil) }
+    it { expect { event.mark_as_started }.to_not change { event.reload.started_on } }
+    it { expect { event.mark_as_started }.to change { event.started_on }.from(nil).to(stubbed_date) }
+  end
+
+  describe '#mark_as_not_started' do
+    let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
+
+    let(:event) { Event.create(started_on: stubbed_date) }
+    it { expect { event.mark_as_not_started }.to_not change { event.reload.started_on } }
+    it { expect { event.mark_as_not_started }.to change { event.started_on }.from(stubbed_date).to(nil) }
+    it { expect(event).to respond_to(:mark_as_unstarted) }
+  end
 end

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -81,4 +81,21 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
     it { expect { event.not_start! }.to change { event.reload.started_at }.from(stubbed_date).to(nil) }
     it { expect(event).to respond_to(:unstart!) }
   end
+
+  describe '#mark_as_started' do
+    let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
+    before { Time.stub(:now).and_return(stubbed_date) }
+
+    let(:event) { Event.create(started_at: nil) }
+    it { expect { event.mark_as_started }.to_not change { event.reload.started_at } }
+    it { expect { event.mark_as_started }.to change { event.started_at }.from(nil).to(stubbed_date) }
+  end
+
+  describe '#mark_as_not_started' do
+    let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
+
+    let(:event) { Event.create(started_at: stubbed_date) }
+    it { expect { event.mark_as_not_started }.to_not change { event.reload.started_at } }
+    it { expect { event.mark_as_not_started }.to change { event.started_at }.from(stubbed_date).to(nil) }
+  end
 end


### PR DESCRIPTION
These methods allow us to set values without saving the record. We’re now able to do this :

``` ruby
class User < ActiveRecord::Base
  acts_as_microscope
end

@user = User.first
@user.mark_as_blocked
@user.blocked? # => true
@user.blocked_at # => 2014-05-23 09:04:35 -0400
@user.reload
@user.blocked? # => false
@user.blocked_at # => nil

# In contrast to:

@user = User.first
@user.block!
@user.blocked? # => true
@user.blocked_at # => 2014-05-23 09:04:35 -0400
@user.reload
@user.blocked? # => true
@user.blocked_at # => 2014-05-23 09:04:35 -0400
```
