### PR TITLE
Add tests for before/after_or_at

### DIFF
--- a/lib/microscope/scope/date_scope.rb
+++ b/lib/microscope/scope/date_scope.rb
@@ -6,7 +6,9 @@ module Microscope
 
         @now = 'Date.today'
         @now_suffix = '_today'
+        @specific_suffix = '_on'
         @cropped_field_regex = /_on$/
+        @formatted_time = 'time.try(:strftime, \'%Y-%m-%d\')'
       end
     end
   end

--- a/lib/microscope/scope/datetime_scope.rb
+++ b/lib/microscope/scope/datetime_scope.rb
@@ -6,7 +6,9 @@ module Microscope
 
         @now = 'Time.now'
         @now_suffix = '_now'
+        @specific_suffix = '_at'
         @cropped_field_regex = /_at$/
+        @formatted_time = 'time'
       end
 
       def apply
@@ -17,12 +19,12 @@ module Microscope
 
       def apply_scopes
         <<-RUBY
-          scope "#{cropped_field}_before", lambda { |time| where('#{quoted_field} < ?', time) }
-          scope "#{cropped_field}_before_or_at", lambda { |time| where('#{quoted_field} <= ?', time) }
+          scope "#{cropped_field}_before", lambda { |time| where('#{quoted_field} < ?', #{@formatted_time}) }
+          scope "#{cropped_field}_before_or#{@specific_suffix}", lambda { |time| where('#{quoted_field} <= ?', #{@formatted_time}) }
           scope "#{cropped_field}_before#{@now_suffix}", lambda { where('#{quoted_field} < ?', #{@now}) }
 
-          scope "#{cropped_field}_after", lambda { |time| where('#{quoted_field} > ?', time) }
-          scope "#{cropped_field}_after_or_at", lambda { |time| where('#{quoted_field} >= ?', time) }
+          scope "#{cropped_field}_after", lambda { |time| where('#{quoted_field} > ?', #{@formatted_time}) }
+          scope "#{cropped_field}_after_or#{@specific_suffix}", lambda { |time| where('#{quoted_field} >= ?', #{@formatted_time}) }
           scope "#{cropped_field}_after#{@now_suffix}", lambda { where('#{quoted_field} > ?', #{@now}) }
 
           scope "#{cropped_field}_between", lambda { |range| where("#{@field_name}" => range) }

--- a/spec/microscope/scope/date_scope_spec.rb
+++ b/spec/microscope/scope/date_scope_spec.rb
@@ -21,6 +21,18 @@ describe Microscope::Scope::DateScope do
     it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
   end
 
+  describe 'before_or_on scope' do
+    let(:date) { 2.months.ago }
+
+    before do
+      @event1 = Event.create(started_on: date)
+      @event2 = Event.create(started_on: date - 1.day)
+      Event.create(started_on: 1.month.from_now)
+    end
+
+    it { expect(Event.started_before_or_on(date).to_a).to eql [@event1, @event2] }
+  end
+
   describe 'before_today scope' do
     before do
       @event = Event.create(started_on: 2.months.ago)
@@ -37,6 +49,18 @@ describe Microscope::Scope::DateScope do
     end
 
     it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
+  end
+
+  describe 'after_or_on scope' do
+    let(:date) { 2.months.from_now }
+
+    before do
+      @event1 = Event.create(started_on: date)
+      @event2 = Event.create(started_on: date + 1.day)
+      Event.create(started_on: 1.month.ago)
+    end
+
+    it { expect(Event.started_after_or_on(date).to_a).to eql [@event1, @event2] }
   end
 
   describe 'after_today scope' do

--- a/spec/microscope/scope/datetime_scope_spec.rb
+++ b/spec/microscope/scope/datetime_scope_spec.rb
@@ -21,6 +21,18 @@ describe Microscope::Scope::DatetimeScope do
     it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
   end
 
+  describe 'before_or_at scope' do
+    let(:datetime) { 1.month.ago }
+
+    before do
+      @event1 = Event.create(started_at: datetime)
+      @event2 = Event.create(started_at: datetime - 1.second)
+      Event.create(started_at: 1.month.from_now)
+    end
+
+    it { expect(Event.started_before_or_at(datetime).to_a).to eql [@event1, @event2] }
+  end
+
   describe 'before_now scope' do
     before do
       @event = Event.create(started_at: 2.months.ago)
@@ -37,6 +49,18 @@ describe Microscope::Scope::DatetimeScope do
     end
 
     it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
+  end
+
+  describe 'after_or_at scope' do
+    let(:datetime) { 1.month.from_now }
+
+    before do
+      @event1 = Event.create(started_at: datetime)
+      @event2 = Event.create(started_at: datetime + 1.second)
+      Event.create(started_at: 1.month.ago)
+    end
+
+    it { expect(Event.started_after_or_at(datetime).to_a).to eql [@event1, @event2] }
   end
 
   describe 'after_now scope' do


### PR DESCRIPTION
I’m in the process of adding a `before/after_or_now` and `before/after_or_today` scopes and I realized we don’t have tests for `before/after_or_at` nor `before/after_or_today`.

So I’m adding these beforehand.
