### PR TITLE
Add bang methods for mark_as aliases

### DIFF
--- a/lib/microscope/instance_method/boolean_instance_method.rb
+++ b/lib/microscope/instance_method/boolean_instance_method.rb
@@ -9,12 +9,15 @@ module Microscope
             send("#{field.name}=", true)
             save!
           end
+          alias_method 'mark_as_#{field.name}!', '#{infinitive_verb}!'
 
           define_method "not_#{infinitive_verb}!" do
             send("#{field.name}=", false)
             save!
           end
           alias_method 'un#{infinitive_verb}!', 'not_#{infinitive_verb}!'
+          alias_method 'mark_as_un#{field.name}!', 'not_#{infinitive_verb}!'
+          alias_method 'mark_as_not_#{field.name}!', 'not_#{infinitive_verb}!'
 
           define_method "mark_as_#{field.name}" do
             send("#{field.name}=", true)

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -64,6 +64,9 @@ module Microscope
       def apply_aliases
         <<-RUBY
           alias_method 'un#{@infinitive_verb}!', 'not_#{@infinitive_verb}!'
+          alias_method 'mark_as_#{@cropped_field}!', '#{@infinitive_verb}!'
+          alias_method 'mark_as_un#{@cropped_field}!', 'not_#{@infinitive_verb}!'
+          alias_method 'mark_as_not_#{@cropped_field}!', 'not_#{@infinitive_verb}!'
           alias_method 'mark_as_un#{@cropped_field}', 'mark_as_not_#{@cropped_field}'
           alias_method 'un#{@cropped_field}?', 'not_#{@cropped_field}?'
         RUBY

--- a/spec/microscope/instance_method/boolean_instance_method_spec.rb
+++ b/spec/microscope/instance_method/boolean_instance_method_spec.rb
@@ -14,12 +14,15 @@ describe Microscope::InstanceMethod::BooleanInstanceMethod do
   describe '#feed!' do
     let(:animal) { Animal.create(fed: false) }
     it { expect { animal.feed! }.to change { animal.reload.fed? }.from(false).to(true) }
+    it { expect(animal).to respond_to(:mark_as_fed!) }
   end
 
   describe '#not_feed!' do
     let(:animal) { Animal.create(fed: true) }
     it { expect { animal.not_feed! }.to change { animal.reload.fed? }.from(true).to(false) }
     it { expect(animal).to respond_to(:unfeed!) }
+    it { expect(animal).to respond_to(:mark_as_unfed!) }
+    it { expect(animal).to respond_to(:mark_as_not_fed!) }
   end
 
   describe '#mark_as_fed' do

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -72,6 +72,7 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
 
     let(:event) { Event.create(started_at: nil) }
     it { expect { event.start! }.to change { event.reload.started_at }.from(nil).to(stubbed_date) }
+    it { expect(event).to respond_to(:mark_as_started!) }
   end
 
   describe '#not_start!' do
@@ -80,6 +81,8 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
     let(:event) { Event.create(started_at: stubbed_date) }
     it { expect { event.not_start! }.to change { event.reload.started_at }.from(stubbed_date).to(nil) }
     it { expect(event).to respond_to(:unstart!) }
+    it { expect(event).to respond_to(:mark_as_unstarted!) }
+    it { expect(event).to respond_to(:mark_as_not_started!) }
   end
 
   describe '#mark_as_started' do


### PR DESCRIPTION
Sometimes, I find it more clear to use the `mark_as` method instead of the infinitive. Take `notified_at` for example:

```ruby
alert = Alert.new
alert.notify!
```

It's not really clear that the method is coming from Microscope. I would much rather do this:

```ruby
alert = Alert.new
alert.mark_as_notified!
```