### PR TITLE
Update rubocop version to 0.28 and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  Include:
+  Exclude:
     - microscope.gemspec
 
 Documentation:
@@ -9,9 +9,6 @@ Encoding:
   Enabled: false
 
 LineLength:
-  Max: 200
-
-ClassLength:
   Max: 200
 
 AccessModifierIndentation:
@@ -37,17 +34,29 @@ ColonMethodCall:
 AsciiComments:
   Enabled: false
 
-Lambda:
-  Enabled: false
-
 RegexpLiteral:
   Enabled: false
 
 AssignmentInCondition:
   Enabled: false
 
-ClassAndModuleChildren:
+ParameterLists:
+  CountKeywordArgs: false
+
+SingleLineBlockParams:
+  Methods:
+    - reduce:
+      - memo
+      - item
+
+Metrics/AbcSize:
   Enabled: false
 
-AbcSize:
-  Enabled: false
+Style/CollectionMethods:
+  Enabled: true
+
+Style/SymbolArray:
+  Enabled: true
+
+Style/ExtraSpacing:
+  Enabled: true

--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -19,18 +19,20 @@ require 'microscope/instance_method/date_instance_method'
 module Microscope
 end
 
-class ActiveRecord::Base
-  def self.acts_as_microscope(options = {})
-    return unless table_exists?
+module ActiveRecord
+  class Base
+    def self.acts_as_microscope(options = {})
+      return unless table_exists?
 
-    except = options[:except] || []
-    model_columns = columns.dup.reject { |c| except.include?(c.name.to_sym) }
+      except = options[:except] || []
+      model_columns = columns.dup.reject { |c| except.include?(c.name.to_sym) }
 
-    if only = options[:only]
-      model_columns = model_columns.select { |c| only.include?(c.name.to_sym) }
+      if only = options[:only]
+        model_columns = model_columns.select { |c| only.include?(c.name.to_sym) }
+      end
+
+      Microscope::Scope.inject_scopes(self, model_columns, options)
+      Microscope::InstanceMethod.inject_instance_methods(self, model_columns, options)
     end
-
-    Microscope::Scope.inject_scopes(self, model_columns, options)
-    Microscope::InstanceMethod.inject_instance_methods(self, model_columns, options)
   end
 end

--- a/microscope.gemspec
+++ b/microscope.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'mysql2', '~> 0.3.13'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'rubocop', '0.27.1'
+  spec.add_development_dependency 'rubocop', '~> 0.28'
   spec.add_development_dependency 'phare'
 end

--- a/spec/microscope_spec.rb
+++ b/spec/microscope_spec.rb
@@ -23,7 +23,7 @@ describe Microscope do
 
     describe :except do
       before do
-        microscope 'User', except: [:admin, :removed_at, :ended_on]
+        microscope 'User', except: %i(admin removed_at ended_on)
       end
 
       it { expect(User).to respond_to :active }
@@ -57,7 +57,7 @@ describe Microscope do
 
     describe :only do
       before do
-        microscope 'User', only: [:admin, :removed_at, :ended_on]
+        microscope 'User', only: %i(admin removed_at ended_on)
       end
 
       it { expect(User).to_not respond_to :active }
@@ -91,7 +91,7 @@ describe Microscope do
 
     describe 'except and only' do
       before do
-        microscope 'User', only: [:admin, :started_on], except: [:active]
+        microscope 'User', only: %i(admin started_on), except: %i(active)
       end
 
       it { expect(User).to_not respond_to :active }


### PR DESCRIPTION
I've excluded the `gemspec` since we're using *unnecessary spacing* according to Rubocop.