### PR TITLE
Do not use extended Struct classes anymore

### DIFF
--- a/lib/microscope/instance_method.rb
+++ b/lib/microscope/instance_method.rb
@@ -1,19 +1,21 @@
 module Microscope
-  class InstanceMethod < Struct.new(:model, :field)
-    def initialize(*args)
-      super
-      @field_name = field.name
+  class InstanceMethod
+    attr_reader :model, :field
+
+    def initialize(model:, field:)
+      @model = model
+      @field = field
     end
 
     def cropped_field
-      @cropped_field ||= @field_name.gsub(@cropped_field_regex, '')
+      @cropped_field ||= @field.name.gsub(@cropped_field_regex, '')
     end
 
     # Inject ActiveRecord scopes into a model
     def self.inject_instance_methods(model, fields, _options)
       fields.each do |field|
         scope = "#{field.type.to_s.camelize}InstanceMethod"
-        "Microscope::InstanceMethod::#{scope}".constantize.new(model, field).apply if const_defined?(scope)
+        "Microscope::InstanceMethod::#{scope}".constantize.new(model: model, field: field).apply if const_defined?(scope)
       end
     end
   end

--- a/lib/microscope/instance_method/datetime_instance_method.rb
+++ b/lib/microscope/instance_method/datetime_instance_method.rb
@@ -11,7 +11,7 @@ module Microscope
       def apply
         @cropped_field = field.name.gsub(@cropped_field_regex, '')
 
-        model.class_eval(apply_methods) if @field_name =~ @cropped_field_regex
+        model.class_eval(apply_methods) if @field.name =~ @cropped_field_regex
       end
 
     protected

--- a/lib/microscope/scope.rb
+++ b/lib/microscope/scope.rb
@@ -1,25 +1,25 @@
 module Microscope
-  class Scope < Struct.new(:model, :field)
-    def initialize(*args)
-      super
+  class Scope
+    attr_reader :model, :field
 
-      @field_name = field.name
-      @table_name = model.name.tableize
+    def initialize(model:, field:)
+      @model = model
+      @field = field
     end
 
     def quoted_field
-      @quoted_field ||= "#{ActiveRecord::Base.connection.quote_table_name(@table_name)}.#{ActiveRecord::Base.connection.quote_column_name(@field_name)}"
+      @quoted_field ||= "#{ActiveRecord::Base.connection.quote_table_name(@model.name.tableize)}.#{ActiveRecord::Base.connection.quote_column_name(@field.name)}"
     end
 
     def cropped_field
-      @cropped_field ||= @field_name.gsub(@cropped_field_regex, '')
+      @cropped_field ||= @field.name.gsub(@cropped_field_regex, '')
     end
 
     # Inject ActiveRecord scopes into a model
     def self.inject_scopes(model, fields, _options)
       fields.each do |field|
         scope = "#{field.type.to_s.camelize}Scope"
-        "Microscope::Scope::#{scope}".constantize.new(model, field).apply if const_defined?(scope)
+        "Microscope::Scope::#{scope}".constantize.new(model: model, field: field).apply if const_defined?(scope)
       end
     end
   end

--- a/lib/microscope/scope/boolean_scope.rb
+++ b/lib/microscope/scope/boolean_scope.rb
@@ -3,9 +3,9 @@ module Microscope
     class BooleanScope < Scope
       def apply
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          scope "#{@field_name}", lambda { where("#{@field_name}" => true) }
-          scope "not_#{@field_name}", lambda { where("#{@field_name}" => false) }
-          scope "un#{@field_name}", lambda { not_#{@field_name} }
+          scope "#{@field.name}", lambda { where("#{@field.name}" => true) }
+          scope "not_#{@field.name}", lambda { where("#{@field.name}" => false) }
+          scope "un#{@field.name}", lambda { not_#{@field.name} }
         RUBY
       end
     end

--- a/lib/microscope/scope/datetime_scope.rb
+++ b/lib/microscope/scope/datetime_scope.rb
@@ -12,7 +12,7 @@ module Microscope
       end
 
       def apply
-        model.class_eval(apply_scopes) if @field_name =~ @cropped_field_regex
+        model.class_eval(apply_scopes) if @field.name =~ @cropped_field_regex
       end
 
     private
@@ -29,7 +29,7 @@ module Microscope
           scope "#{cropped_field}_after#{@now_suffix}", lambda { where('#{quoted_field} > ?', #{@now}) }
           scope "#{cropped_field}_after_or#{@now_suffix}", lambda { where('#{quoted_field} >= ?', #{@now}) }
 
-          scope "#{cropped_field}_between", lambda { |range| where("#{@field_name}" => range) }
+          scope "#{cropped_field}_between", lambda { |range| where("#{@field.name}" => range) }
 
           scope "#{cropped_field}", lambda { where('#{quoted_field} IS NOT NULL AND #{quoted_field} <= ?', #{@now}) }
           scope "not_#{cropped_field}", lambda { where('#{quoted_field} IS NULL OR #{quoted_field} > ?', #{@now}) }

--- a/microscope.gemspec
+++ b/microscope.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'mysql2', '~> 0.3.13'
-  spec.add_development_dependency 'rubocop', '~> 0.28'
+  spec.add_development_dependency 'rubocop', '0.29'
   spec.add_development_dependency 'phare'
 end


### PR DESCRIPTION
Rubocop 0.29 does not allow extending `Struct` subclasses. It looks actually better that way!