### PR TITLE
Modify scopes to handle blacklisted scope name

### DIFF
--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -17,6 +17,11 @@ require 'microscope/instance_method/datetime_instance_method'
 require 'microscope/instance_method/date_instance_method'
 
 module Microscope
+  # Constants
+  BlacklistedColumnsErrorMessage = 'The `%s` column cannot be used with Microscope because it’s on ActiveRecord’s method name blacklist.'.freeze
+
+  # Errors
+  BlacklistedColumnsError = Class.new(StandardError)
 end
 
 module ActiveRecord

--- a/lib/microscope/scope.rb
+++ b/lib/microscope/scope.rb
@@ -22,5 +22,17 @@ module Microscope
         "Microscope::Scope::#{scope}".constantize.new(model, field).apply if const_defined?(scope)
       end
     end
+
+  protected
+
+    def blacklisted_fields
+      return [] unless defined? ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS
+
+      ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS
+    end
+
+    def validate_field_name!(cropped_field_name, field_name)
+      raise Microscope::BlacklistedColumnsError, Microscope::BlacklistedColumnsErrorMessage % field_name if blacklisted_fields.include?(cropped_field_name)
+    end
   end
 end

--- a/lib/microscope/scope/boolean_scope.rb
+++ b/lib/microscope/scope/boolean_scope.rb
@@ -2,6 +2,8 @@ module Microscope
   class Scope
     class BooleanScope < Scope
       def apply
+        validate_field_name!(@field.name, @field.name)
+
         model.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           scope "#{@field.name}", lambda { where("#{@field.name}" => true) }
           scope "not_#{@field.name}", lambda { where("#{@field.name}" => false) }

--- a/lib/microscope/scope/datetime_scope.rb
+++ b/lib/microscope/scope/datetime_scope.rb
@@ -12,7 +12,10 @@ module Microscope
       end
 
       def apply
-        model.class_eval(apply_scopes) if @field.name =~ @cropped_field_regex
+        return unless @field.name =~ @cropped_field_regex
+
+        validate_field_name!(cropped_field, @field.name)
+        model.class_eval(apply_scopes)
       end
 
     private

--- a/spec/microscope/scope/boolean_scope_spec.rb
+++ b/spec/microscope/scope/boolean_scope_spec.rb
@@ -1,36 +1,50 @@
 require 'spec_helper'
 
 describe Microscope::Scope::BooleanScope do
-  before do
-    run_migration do
-      create_table(:oh_users, force: true) do |t|
-        t.boolean :active, default: false
+  describe 'for a valid column name' do
+    before do
+      run_migration do
+        create_table(:oh_users, force: true) do |t|
+          t.boolean :active, default: false
+        end
+      end
+
+      microscope 'User' do
+        self.table_name = 'oh_users'
       end
     end
 
-    microscope 'User' do
-      self.table_name = 'oh_users'
+    describe 'positive scope' do
+      before do
+        @user1 = User.create(active: true)
+        @user2 = User.create(active: false)
+      end
+
+      it { expect(User.active.length).to eql 1 }
+      it { expect(User.active).to include(@user1) }
+    end
+
+    describe 'negative scope' do
+      before do
+        @user1 = User.create(active: false)
+        @user2 = User.create(active: true)
+      end
+
+      it { expect(User.not_active.length).to eql 1 }
+      it { expect(User.not_active).to include(@user1) }
+      it { expect(User.unactive.to_a).to eql User.not_active.to_a }
     end
   end
 
-  describe 'positive scope' do
+  describe 'for a invalid column name' do
     before do
-      @user1 = User.create(active: true)
-      @user2 = User.create(active: false)
+      run_migration do
+        create_table(:users, force: true) do |t|
+          t.boolean :public, default: false
+        end
+      end
     end
 
-    it { expect(User.active.length).to eql 1 }
-    it { expect(User.active).to include(@user1) }
-  end
-
-  describe 'negative scope' do
-    before do
-      @user1 = User.create(active: false)
-      @user2 = User.create(active: true)
-    end
-
-    it { expect(User.not_active.length).to eql 1 }
-    it { expect(User.not_active).to include(@user1) }
-    it { expect(User.unactive.to_a).to eql User.not_active.to_a }
+    it { expect { microscope 'User' }.to raise_error(Microscope::BlacklistedColumnsError) }
   end
 end

--- a/spec/microscope/scope/date_scope_spec.rb
+++ b/spec/microscope/scope/date_scope_spec.rb
@@ -1,150 +1,164 @@
 require 'spec_helper'
 
 describe Microscope::Scope::DateScope do
-  before do
-    run_migration do
-      create_table(:events, force: true) do |t|
-        t.date :started_on, default: nil
-        t.date :published_date, default: nil
+  describe 'for a valid column name' do
+    before do
+      run_migration do
+        create_table(:events, force: true) do |t|
+          t.date :started_on, default: nil
+          t.date :published_date, default: nil
+        end
+      end
+
+      microscope 'Event'
+    end
+
+    describe 'before scope' do
+      before do
+        @event = Event.create(started_on: 2.months.ago)
+        Event.create(started_on: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
+    end
+
+    describe 'before_or_on scope' do
+      let(:date) { 2.months.ago }
+
+      before do
+        @event1 = Event.create(started_on: date)
+        @event2 = Event.create(started_on: date - 1.day)
+        Event.create(started_on: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before_or_on(date).to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'before_or_now scope' do
+      let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
+      before { allow(Date).to receive(:today).and_return(stubbed_date) }
+
+      before do
+        @event1 = Event.create(started_on: stubbed_date)
+        @event2 = Event.create(started_on: stubbed_date - 1.day)
+        Event.create(started_on: stubbed_date + 1.week)
+      end
+
+      it { expect(Event.started_before_or_today.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'before_today scope' do
+      before do
+        @event = Event.create(started_on: 2.months.ago)
+        Event.create(started_on: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before_today.to_a).to eql [@event] }
+    end
+
+    describe 'after scope' do
+      before do
+        @event = Event.create(started_on: 2.months.from_now)
+        Event.create(started_on: 1.month.ago)
+      end
+
+      it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
+    end
+
+    describe 'after_or_on scope' do
+      let(:date) { 2.months.from_now }
+
+      before do
+        @event1 = Event.create(started_on: date)
+        @event2 = Event.create(started_on: date + 1.day)
+        Event.create(started_on: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_or_on(date).to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'after_or_now scope' do
+      let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
+      before { allow(Date).to receive(:today).and_return(stubbed_date) }
+
+      before do
+        @event1 = Event.create(started_on: stubbed_date)
+        @event2 = Event.create(started_on: stubbed_date + 1.day)
+        Event.create(started_on: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_or_today.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'after_today scope' do
+      before do
+        @event = Event.create(started_on: 2.months.from_now)
+        Event.create(started_on: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_today.to_a).to eql [@event] }
+    end
+
+    describe 'between scope' do
+      before do
+        Event.create(started_on: 1.month.ago)
+        @event = Event.create(started_on: 3.months.ago)
+        Event.create(started_on: 5.month.ago)
+      end
+
+      it { expect(Event.started_between(4.months.ago..2.months.ago).to_a).to eql [@event] }
+    end
+
+    describe 'super-boolean positive scope' do
+      before do
+        @event1 = Event.create(started_on: 1.month.ago)
+        @event2 = Event.create(started_on: 3.months.ago)
+        Event.create(started_on: 2.months.from_now)
+        Event.create(started_on: nil)
+      end
+
+      it { expect(Event.started.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'super-boolean negative scope' do
+      before do
+        Event.create(started_on: 1.month.ago)
+        Event.create(started_on: 3.months.ago)
+        @event1 = Event.create(started_on: 2.months.from_now)
+        @event2 = Event.create(started_on: nil)
+      end
+
+      it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
+      it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
+    end
+
+    describe 'boolean instance method' do
+      context 'for positive record' do
+        let(:event) { Event.create(started_on: 3.months.ago) }
+        it { expect(event).to be_started }
+      end
+
+      context 'for negative record' do
+        let(:event) { Event.create(started_on: 2.months.from_now) }
+        it { expect(event).to_not be_started }
       end
     end
 
-    microscope 'Event'
+    context 'for field that does not match the pattern' do
+      it { expect(Event).to_not respond_to(:published_date) }
+      it { expect(Event).to_not respond_to(:not_published_date) }
+    end
   end
 
-  describe 'before scope' do
+  describe 'for a invalid column name' do
     before do
-      @event = Event.create(started_on: 2.months.ago)
-      Event.create(started_on: 1.month.from_now)
+      run_migration do
+        create_table(:events, force: true) do |t|
+          t.date :public_on, default: nil
+        end
+      end
     end
 
-    it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
-  end
-
-  describe 'before_or_on scope' do
-    let(:date) { 2.months.ago }
-
-    before do
-      @event1 = Event.create(started_on: date)
-      @event2 = Event.create(started_on: date - 1.day)
-      Event.create(started_on: 1.month.from_now)
-    end
-
-    it { expect(Event.started_before_or_on(date).to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'before_or_now scope' do
-    let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
-    before { allow(Date).to receive(:today).and_return(stubbed_date) }
-
-    before do
-      @event1 = Event.create(started_on: stubbed_date)
-      @event2 = Event.create(started_on: stubbed_date - 1.day)
-      Event.create(started_on: stubbed_date + 1.week)
-    end
-
-    it { expect(Event.started_before_or_today.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'before_today scope' do
-    before do
-      @event = Event.create(started_on: 2.months.ago)
-      Event.create(started_on: 1.month.from_now)
-    end
-
-    it { expect(Event.started_before_today.to_a).to eql [@event] }
-  end
-
-  describe 'after scope' do
-    before do
-      @event = Event.create(started_on: 2.months.from_now)
-      Event.create(started_on: 1.month.ago)
-    end
-
-    it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
-  end
-
-  describe 'after_or_on scope' do
-    let(:date) { 2.months.from_now }
-
-    before do
-      @event1 = Event.create(started_on: date)
-      @event2 = Event.create(started_on: date + 1.day)
-      Event.create(started_on: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_or_on(date).to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'after_or_now scope' do
-    let(:stubbed_date) { Date.parse('2020-03-18 08:00:00') }
-    before { allow(Date).to receive(:today).and_return(stubbed_date) }
-
-    before do
-      @event1 = Event.create(started_on: stubbed_date)
-      @event2 = Event.create(started_on: stubbed_date + 1.day)
-      Event.create(started_on: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_or_today.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'after_today scope' do
-    before do
-      @event = Event.create(started_on: 2.months.from_now)
-      Event.create(started_on: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_today.to_a).to eql [@event] }
-  end
-
-  describe 'between scope' do
-    before do
-      Event.create(started_on: 1.month.ago)
-      @event = Event.create(started_on: 3.months.ago)
-      Event.create(started_on: 5.month.ago)
-    end
-
-    it { expect(Event.started_between(4.months.ago..2.months.ago).to_a).to eql [@event] }
-  end
-
-  describe 'super-boolean positive scope' do
-    before do
-      @event1 = Event.create(started_on: 1.month.ago)
-      @event2 = Event.create(started_on: 3.months.ago)
-      Event.create(started_on: 2.months.from_now)
-      Event.create(started_on: nil)
-    end
-
-    it { expect(Event.started.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'super-boolean negative scope' do
-    before do
-      Event.create(started_on: 1.month.ago)
-      Event.create(started_on: 3.months.ago)
-      @event1 = Event.create(started_on: 2.months.from_now)
-      @event2 = Event.create(started_on: nil)
-    end
-
-    it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
-    it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
-  end
-
-  describe 'boolean instance method' do
-    context 'for positive record' do
-      let(:event) { Event.create(started_on: 3.months.ago) }
-      it { expect(event).to be_started }
-    end
-
-    context 'for negative record' do
-      let(:event) { Event.create(started_on: 2.months.from_now) }
-      it { expect(event).to_not be_started }
-    end
-  end
-
-  context 'for field that does not match the pattern' do
-    it { expect(Event).to_not respond_to(:published_date) }
-    it { expect(Event).to_not respond_to(:not_published_date) }
+    it { expect { microscope 'Event' }.to raise_error(Microscope::BlacklistedColumnsError) }
   end
 end

--- a/spec/microscope/scope/datetime_scope_spec.rb
+++ b/spec/microscope/scope/datetime_scope_spec.rb
@@ -1,150 +1,164 @@
 require 'spec_helper'
 
 describe Microscope::Scope::DatetimeScope do
-  before do
-    run_migration do
-      create_table(:events, force: true) do |t|
-        t.datetime :started_at, default: nil
-        t.datetime :published_date, default: nil
+  describe 'for a valid column name' do
+    before do
+      run_migration do
+        create_table(:events, force: true) do |t|
+          t.datetime :started_at, default: nil
+          t.datetime :published_date, default: nil
+        end
+      end
+
+      microscope 'Event'
+    end
+
+    describe 'before scope' do
+      before do
+        @event = Event.create(started_at: 2.months.ago)
+        Event.create(started_at: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
+    end
+
+    describe 'before_or_at scope' do
+      let(:datetime) { 1.month.ago }
+
+      before do
+        @event1 = Event.create(started_at: datetime)
+        @event2 = Event.create(started_at: datetime - 1.second)
+        Event.create(started_at: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before_or_at(datetime).to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'before_or_now scope' do
+      let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
+      before { allow(Time).to receive(:now).and_return(stubbed_date) }
+
+      before do
+        @event1 = Event.create(started_at: stubbed_date)
+        @event2 = Event.create(started_at: stubbed_date - 1.second)
+        Event.create(started_at: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before_or_now.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'before_now scope' do
+      before do
+        @event = Event.create(started_at: 2.months.ago)
+        Event.create(started_at: 1.month.from_now)
+      end
+
+      it { expect(Event.started_before_now.to_a).to eql [@event] }
+    end
+
+    describe 'after scope' do
+      before do
+        @event = Event.create(started_at: 2.months.from_now)
+        Event.create(started_at: 1.month.ago)
+      end
+
+      it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
+    end
+
+    describe 'after_or_at scope' do
+      let(:datetime) { 1.month.from_now }
+
+      before do
+        @event1 = Event.create(started_at: datetime)
+        @event2 = Event.create(started_at: datetime + 1.second)
+        Event.create(started_at: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_or_at(datetime).to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'after_or_now scope' do
+      let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
+      before { allow(Time).to receive(:now).and_return(stubbed_date) }
+
+      before do
+        @event1 = Event.create(started_at: stubbed_date)
+        @event2 = Event.create(started_at: stubbed_date + 1.second)
+        Event.create(started_at: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_or_now.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'after_now scope' do
+      before do
+        @event = Event.create(started_at: 2.months.from_now)
+        Event.create(started_at: 1.month.ago)
+      end
+
+      it { expect(Event.started_after_now.to_a).to eql [@event] }
+    end
+
+    describe 'between scope' do
+      before do
+        Event.create(started_at: 1.month.ago)
+        @event = Event.create(started_at: 3.months.ago)
+        Event.create(started_at: 5.month.ago)
+      end
+
+      it { expect(Event.started_between(4.months.ago..2.months.ago).to_a).to eql [@event] }
+    end
+
+    describe 'super-boolean positive scope', focus: true do
+      before do
+        @event1 = Event.create(started_at: 1.month.ago)
+        @event2 = Event.create(started_at: 3.months.ago)
+        Event.create(started_at: 2.months.from_now)
+        Event.create(started_at: nil)
+      end
+
+      it { expect(Event.started.to_a).to eql [@event1, @event2] }
+    end
+
+    describe 'super-boolean negative scope' do
+      before do
+        Event.create(started_at: 1.month.ago)
+        Event.create(started_at: 3.months.ago)
+        @event1 = Event.create(started_at: 2.months.from_now)
+        @event2 = Event.create(started_at: nil)
+      end
+
+      it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
+      it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
+    end
+
+    describe 'boolean instance method' do
+      context 'for positive record' do
+        let(:event) { Event.create(started_at: 3.months.ago) }
+        it { expect(event).to be_started }
+      end
+
+      context 'for negative record' do
+        let(:event) { Event.create(started_at: 2.months.from_now) }
+        it { expect(event).to_not be_started }
       end
     end
 
-    microscope 'Event'
+    context 'for field that does not match the pattern' do
+      it { expect(Event).to_not respond_to(:published_date) }
+      it { expect(Event).to_not respond_to(:not_published_date) }
+    end
   end
 
-  describe 'before scope' do
+  describe 'for a invalid column name' do
     before do
-      @event = Event.create(started_at: 2.months.ago)
-      Event.create(started_at: 1.month.from_now)
+      run_migration do
+        create_table(:events, force: true) do |t|
+          t.datetime :public_at, default: nil
+        end
+      end
     end
 
-    it { expect(Event.started_before(1.month.ago).to_a).to eql [@event] }
-  end
-
-  describe 'before_or_at scope' do
-    let(:datetime) { 1.month.ago }
-
-    before do
-      @event1 = Event.create(started_at: datetime)
-      @event2 = Event.create(started_at: datetime - 1.second)
-      Event.create(started_at: 1.month.from_now)
-    end
-
-    it { expect(Event.started_before_or_at(datetime).to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'before_or_now scope' do
-    let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
-    before { allow(Time).to receive(:now).and_return(stubbed_date) }
-
-    before do
-      @event1 = Event.create(started_at: stubbed_date)
-      @event2 = Event.create(started_at: stubbed_date - 1.second)
-      Event.create(started_at: 1.month.from_now)
-    end
-
-    it { expect(Event.started_before_or_now.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'before_now scope' do
-    before do
-      @event = Event.create(started_at: 2.months.ago)
-      Event.create(started_at: 1.month.from_now)
-    end
-
-    it { expect(Event.started_before_now.to_a).to eql [@event] }
-  end
-
-  describe 'after scope' do
-    before do
-      @event = Event.create(started_at: 2.months.from_now)
-      Event.create(started_at: 1.month.ago)
-    end
-
-    it { expect(Event.started_after(1.month.from_now).to_a).to eql [@event] }
-  end
-
-  describe 'after_or_at scope' do
-    let(:datetime) { 1.month.from_now }
-
-    before do
-      @event1 = Event.create(started_at: datetime)
-      @event2 = Event.create(started_at: datetime + 1.second)
-      Event.create(started_at: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_or_at(datetime).to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'after_or_now scope' do
-    let(:stubbed_date) { Time.parse('2020-03-18 08:00:00') }
-    before { allow(Time).to receive(:now).and_return(stubbed_date) }
-
-    before do
-      @event1 = Event.create(started_at: stubbed_date)
-      @event2 = Event.create(started_at: stubbed_date + 1.second)
-      Event.create(started_at: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_or_now.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'after_now scope' do
-    before do
-      @event = Event.create(started_at: 2.months.from_now)
-      Event.create(started_at: 1.month.ago)
-    end
-
-    it { expect(Event.started_after_now.to_a).to eql [@event] }
-  end
-
-  describe 'between scope' do
-    before do
-      Event.create(started_at: 1.month.ago)
-      @event = Event.create(started_at: 3.months.ago)
-      Event.create(started_at: 5.month.ago)
-    end
-
-    it { expect(Event.started_between(4.months.ago..2.months.ago).to_a).to eql [@event] }
-  end
-
-  describe 'super-boolean positive scope', focus: true do
-    before do
-      @event1 = Event.create(started_at: 1.month.ago)
-      @event2 = Event.create(started_at: 3.months.ago)
-      Event.create(started_at: 2.months.from_now)
-      Event.create(started_at: nil)
-    end
-
-    it { expect(Event.started.to_a).to eql [@event1, @event2] }
-  end
-
-  describe 'super-boolean negative scope' do
-    before do
-      Event.create(started_at: 1.month.ago)
-      Event.create(started_at: 3.months.ago)
-      @event1 = Event.create(started_at: 2.months.from_now)
-      @event2 = Event.create(started_at: nil)
-    end
-
-    it { expect(Event.not_started.to_a).to eql [@event1, @event2] }
-    it { expect(Event.unstarted.to_a).to eql Event.not_started.to_a }
-  end
-
-  describe 'boolean instance method' do
-    context 'for positive record' do
-      let(:event) { Event.create(started_at: 3.months.ago) }
-      it { expect(event).to be_started }
-    end
-
-    context 'for negative record' do
-      let(:event) { Event.create(started_at: 2.months.from_now) }
-      it { expect(event).to_not be_started }
-    end
-  end
-
-  context 'for field that does not match the pattern' do
-    it { expect(Event).to_not respond_to(:published_date) }
-    it { expect(Event).to_not respond_to(:not_published_date) }
+    it { expect { microscope 'Event' }.to raise_error(Microscope::BlacklistedColumnsError) }
   end
 end


### PR DESCRIPTION
Sorry for the huge diff. All `scope` specs was re indented to add new test.

Since `ActiveRecord` `4.1`, you can't have a method named `public`, `protected` or `private`. Currently if `Microscope` try to create a new scope named `public`, `ActiveRecord` was rising a exception.

We now handle this case in `Microscope` to raise a exception more meaningful for the user who is using this gem.