### PR TITLE
Prevent error when using “acts_on_microscope” when database is not available yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: ruby
 sudo: false
 
-rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+rvm: 2.3
 
 gemfile:
   - gemfiles/Gemfile.activerecord-4.1
+  - gemfiles/Gemfile.activerecord-4.2
+  - gemfiles/Gemfile.activerecord-5.1
+  - gemfiles/Gemfile.activerecord-5.2
 
 env:
   - DB_ADAPTER=sqlite3
   - DB_ADAPTER=mysql2
   - DB_ADAPTER=postgresql
+
+before_install:
+  - gem update --system
+  - gem install bundler
 
 before_script:
   - mysql -e 'create database microscope_test;'
@@ -21,11 +25,3 @@ before_script:
 script:
   - 'echo "Checking code style" && bundle exec phare'
   - 'echo "Running tests" && bundle exec rake spec'
-
-notifications:
-  hipchat:
-    rooms:
-      secure: cJWiEh3XNWrEkoeaZd5Kyx3igwOJto+B8jPiyr38Kfv8Z2WLINkHbMQXcd37/tIubX6w9VWjWJ2TuX5cK2H07EraPDDYAHJlnoR/WIPoYwQoXGUWqGH26O2LdBiLs9JcBQ9rKT8K8wmQuxf2rTpY7lN2RoKMjjEjcleWJwQG/3w=
-    template:
-      - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Build</a>/<a href="%{compare_url}">Changes</a>)'
-    format: 'html'

--- a/gemfiles/Gemfile.activerecord-4.2
+++ b/gemfiles/Gemfile.activerecord-4.2
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 4.1.0'
+gem 'activerecord', '~> 4.2.0'
 gem 'sqlite3', '~> 1.3.6'
-gem 'mysql2', '~> 0.3.0'
+gem 'mysql2', '~> 0.4.0'
 gem 'pg', '~> 0.15.0'

--- a/gemfiles/Gemfile.activerecord-5.1
+++ b/gemfiles/Gemfile.activerecord-5.1
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 4.1.0'
+gem 'activerecord', '~> 5.1.0'
 gem 'sqlite3', '~> 1.3.6'
-gem 'mysql2', '~> 0.3.0'
-gem 'pg', '~> 0.15.0'
+gem 'mysql2', '~> 0.4.0'
+gem 'pg', '~> 0.18.0'

--- a/gemfiles/Gemfile.activerecord-5.2
+++ b/gemfiles/Gemfile.activerecord-5.2
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 4.1.0'
+gem 'activerecord', '~> 5.2.0'
 gem 'sqlite3', '~> 1.3.6'
-gem 'mysql2', '~> 0.3.0'
-gem 'pg', '~> 0.15.0'
+gem 'mysql2', '~> 0.4.0'
+gem 'pg', '~> 0.18.0'

--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -38,6 +38,8 @@ module ActiveRecord
 
       Microscope::Scope.inject_scopes(self, model_columns, options)
       Microscope::InstanceMethod.inject_instance_methods(self, model_columns, options)
+    rescue ActiveRecord::NoDatabaseError
+      nil
     end
   end
 end

--- a/microscope.gemspec
+++ b/microscope.gemspec
@@ -18,15 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 3.0.0'
-  spec.add_dependency 'activerecord', '>= 3.0.0'
+  spec.add_dependency 'activesupport', '>= 4.1.0'
+  spec.add_dependency 'activerecord', '>= 4.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.1'
-  spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'pg'
-  spec.add_development_dependency 'mysql2', '~> 0.3.13'
   spec.add_development_dependency 'rubocop', '0.29'
   spec.add_development_dependency 'phare'
 end

--- a/spec/microscope/instance_method/datetime_instance_method_spec.rb
+++ b/spec/microscope/instance_method/datetime_instance_method_spec.rb
@@ -42,7 +42,7 @@ describe Microscope::InstanceMethod::DatetimeInstanceMethod do
 
     context 'with present argument, twice' do
       let(:event) { Event.create(started_at: time) }
-      let(:time) { 2.months.ago }
+      let(:time) { 2.months.ago.beginning_of_hour }
       let(:value) { '1' }
 
       it { expect(event.started_at).to eql time }

--- a/spec/microscope/scope/datetime_scope_spec.rb
+++ b/spec/microscope/scope/datetime_scope_spec.rb
@@ -66,7 +66,7 @@ describe Microscope::Scope::DatetimeScope do
     end
 
     describe 'after_or_at scope' do
-      let(:datetime) { 1.month.from_now }
+      let(:datetime) { 1.month.from_now.beginning_of_hour }
 
       before do
         @event1 = Event.create(started_at: datetime)

--- a/spec/microscope_spec.rb
+++ b/spec/microscope_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe Microscope do
+  describe :acts_as_microscope_without_database do
+    specify do
+      adapter = ENV['DB_ADAPTER'] || 'sqlite3'
+      setup_database(adapter: adapter, database: 'microscope_test_that_does_not_exist')
+
+      class User < ActiveRecord::Base
+        acts_as_microscope
+      end
+    end
+  end
+
   describe :acts_as_microscope do
     before do
       run_migration do

--- a/spec/support/macros/database/mysql2_adapter.rb
+++ b/spec/support/macros/database/mysql2_adapter.rb
@@ -12,5 +12,7 @@ class Mysql2Adapter < DatabaseAdapter
 
   def reset_database!
     ActiveRecord::Base.connection.execute("SELECT concat('DROP TABLE IF EXISTS ', table_name, ';') FROM information_schema.tables WHERE table_schema = '#{@database}';")
+  rescue ActiveRecord::NoDatabaseError
+    nil
   end
 end

--- a/spec/support/macros/database/postgresql_adapter.rb
+++ b/spec/support/macros/database/postgresql_adapter.rb
@@ -13,5 +13,7 @@ class PostgresqlAdapter < DatabaseAdapter
   def reset_database!
     ActiveRecord::Base.connection.execute('drop schema public cascade;')
     ActiveRecord::Base.connection.execute('create schema public;')
+  rescue ActiveRecord::NoDatabaseError
+    nil
   end
 end

--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -2,7 +2,11 @@ module DatabaseMacros
   # Run migrations in the test database
   def run_migration(&block)
     # Create a new migration class
-    klass = Class.new(ActiveRecord::Migration)
+    if ActiveRecord.version >= Gem::Version.new('5.0')
+      klass = Class.new(ActiveRecord::Migration[ActiveRecord.version.to_s.to_f])
+    else
+      klass = Class.new(ActiveRecord::Migration)
+    end
 
     # Create a new `up` that executes the argument
     klass.send(:define_method, :up) { instance_exec(&block) }


### PR DESCRIPTION
Running `rake db:create` evaluates the whole application codebase, so calls to `acts_as_microscope` were crashing the command because they call `table_exists?` (which tries to connect to the database).

The whole bugfix is the `rescue` in `lib/microscope.rb` (and the related test case), but I had to do some maintenance to get the Travis build to pass 😄

We now test for Ruby 2.3 (because Bundler 2.0 doesn’t support previous versions) against various Rails versions. The gem should keep working on Ruby 2.1 and 2.2 but we don’t have the time and motivation anymore to maintain a working test setup for these versions.

Fixes #38