### PR TITLE
Prevent lib crash when no database connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ gemfile:
   - gemfiles/Gemfile.activerecord-4.2
   - gemfiles/Gemfile.activerecord-5.1
   - gemfiles/Gemfile.activerecord-5.2
+  - gemfiles/Gemfile.activerecord-6.1
 
 env:
   - DB_ADAPTER=sqlite3

--- a/gemfiles/Gemfile.activerecord-6.1
+++ b/gemfiles/Gemfile.activerecord-6.1
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.0'
+gem 'sqlite3', '~> 1.3.6'
+gem 'mysql2', '~> 0.4.0'
+gem 'pg', '~> 0.18.0'

--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -27,7 +27,7 @@ end
 module ActiveRecord
   class Base
     def self.acts_as_microscope(options = {})
-      return unless table_exists?
+      return unless connected? && table_exists?
 
       except = options[:except] || []
       model_columns = columns.dup.reject { |c| except.include?(c.name.to_sym) }

--- a/lib/microscope/scope.rb
+++ b/lib/microscope/scope.rb
@@ -26,9 +26,13 @@ module Microscope
   protected
 
     def blacklisted_fields
-      return [] unless defined? ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS
+      # ActiveRecord 6.1
+      return ActiveRecord::AttributeMethods::RESTRICTED_CLASS_METHODS if defined? ActiveRecord::AttributeMethods::RESTRICTED_CLASS_METHODS
 
-      ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS
+      # ActiveRecord < 6
+      return ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS if defined? ActiveRecord::AttributeMethods::BLACKLISTED_CLASS_METHODS
+
+      []
     end
 
     def validate_field_name!(cropped_field_name, field_name)

--- a/microscope.gemspec
+++ b/microscope.gemspec
@@ -26,4 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rubocop', '0.29'
   spec.add_development_dependency 'phare'
+  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'mysql2'
+  spec.add_development_dependency 'pg'
 end

--- a/spec/microscope/scope/date_scope_spec.rb
+++ b/spec/microscope/scope/date_scope_spec.rb
@@ -84,7 +84,7 @@ describe Microscope::Scope::DateScope do
       before do
         @event1 = Event.create(started_on: stubbed_date)
         @event2 = Event.create(started_on: stubbed_date + 1.day)
-        Event.create(started_on: 1.month.ago)
+        Event.create(started_on: stubbed_date - 1.month)
       end
 
       it { expect(Event.started_after_or_today.to_a).to eql [@event1, @event2] }

--- a/spec/microscope_spec.rb
+++ b/spec/microscope_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe Microscope do
+  describe :acts_as_microscope_without_connection do
+    specify do
+      setup_database(adapter: 'invalid', database: 'invalid_database')
+
+      class User < ActiveRecord::Base
+        acts_as_microscope
+      end
+    end
+  end
+
   describe :acts_as_microscope_without_database do
     specify do
       adapter = ENV['DB_ADAPTER'] || 'sqlite3'

--- a/spec/support/macros/database/invalid_adapter.rb
+++ b/spec/support/macros/database/invalid_adapter.rb
@@ -1,0 +1,12 @@
+require_relative 'database_adapter'
+
+class InvalidAdapter < DatabaseAdapter
+  def database_configuration
+    {
+      adapter: 'postgresql',
+    }
+  end
+
+  def reset_database!
+  end
+end

--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -16,9 +16,13 @@ module DatabaseMacros
   end
 
   def setup_database(opts = {})
-    adapter = "#{opts[:adapter].capitalize}Adapter".constantize.new(database: opts[:database])
-    adapter.establish_connection!
-    adapter.reset_database!
+    begin
+      adapter = "#{opts[:adapter].capitalize}Adapter".constantize.new(database: opts[:database])
+      adapter.establish_connection!
+      adapter.reset_database!
+    rescue ActiveRecord::ConnectionNotEstablished
+      nil
+    end
 
     # Silence everything
     ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = false


### PR DESCRIPTION
When this gem is included and there is no connection to a database, there are multiple exceptions that can be raised by the `table_exists?` call including `ActiveRecord::ConnectionNotEstablished` or `PG::ConnectionBad`.

By checking the result of `connected?` available with `ActiveRecord`, we make sure the call to `table_exists?` does not throw an exception.