### PR TITLE
Rescue *all* ActiveRecord errors on initialization

### DIFF
--- a/lib/microscope.rb
+++ b/lib/microscope.rb
@@ -38,7 +38,7 @@ module ActiveRecord
 
       Microscope::Scope.inject_scopes(self, model_columns, options)
       Microscope::InstanceMethod.inject_instance_methods(self, model_columns, options)
-    rescue ActiveRecord::NoDatabaseError
+    rescue ActiveRecord::ActiveRecordError
       nil
     end
   end


### PR DESCRIPTION
We now rescue `ActiveRecord::ActiveRecordError` instead of `ActiveRecord::NoDatabaseError` to ignore _more_ errors.

This should fix #41. /cc @jdwyah